### PR TITLE
Make sure the sort is stable

### DIFF
--- a/pages/api/nft-listings.ts
+++ b/pages/api/nft-listings.ts
@@ -17,10 +17,11 @@ const nftListingsHandler = Validate({
 
       await trySaveNewNFTListings()
 
+      const idOrder = (priceOrder === 'asc' || priceOrder === 'ascending') ? -1 : 1
       const filterArgs = searchText ? { $text: { $search: searchText, $caseSensitive: false } } : {}
       const skipped = page * size
       const listings = priceOrder ?
-        await NFTListing.find(filterArgs).sort({ "price": priceOrder }).collation({ locale: "en_US", numericOrdering: true }).skip(skipped).limit(size) :
+        await NFTListing.find(filterArgs).sort({ "price": priceOrder, "_id": idOrder }).collation({ locale: "en_US", numericOrdering: true }).skip(skipped).limit(size) :
         await NFTListing.find(filterArgs).sort({ "createdAt": -1 }).skip(skipped).limit(size)
       res.json(listings)
     } catch (err) {


### PR DESCRIPTION
The sorting in MongoDB is not stable. When we sort NFTs based on price and retrieve them in pagination, it can result in the same NFT appearing multiple times. For example on our [testnet](https://testnet.nft.alephium.org/):

1. Sort the hot listings by `Price (low to high)`
2. This NFT will appear on both the first and second pages: https://testnet.nft.alephium.org/nft-details?tokenId=e172db28e11ee4e99a8561dd1a17810264a218dffd0dcaee0097628b59f22300