### PR TITLE
Fix display of number with scientific notation

### DIFF
--- a/components/NFTCard.tsx
+++ b/components/NFTCard.tsx
@@ -2,9 +2,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { shortenAddress } from '../utils/address';
-import { shortenName } from '../utils';
+import { formatAlphAmount, shortenName } from '../utils';
 import { motion } from 'framer-motion';
-import { prettifyNumber, prettifyNumberConfig } from '@alephium/web3';
 
 interface NFTCardProps {
   nft: {
@@ -51,7 +50,7 @@ const NFTCard = ({ nft }: NFTCardProps) => {
             {
               nft.price ? (
                 <p className="font-poppins dark:text-white text-nft-black-1 font-semibold text-xs minlg:text-lg">
-                  {formatNFTPrice(nft.price)} <span className="normal">ALPH</span>
+                  {formatAlphAmount(nft.price)} <span className="normal">ALPH</span>
                 </p>
               ) : null
             }
@@ -66,27 +65,5 @@ const NFTCard = ({ nft }: NFTCardProps) => {
     </Link>
   );
 };
-
-const prettifyConfig = {
-  ...prettifyNumberConfig['ALPH'],
-  maxDecimalPlaces: 2
-}
-
-function formatNFTPrice(price: bigint): string | undefined {
-  const priceStr = price.toString()
-  if (priceStr.length > 24) {
-    return prettifyNumberWithUnit(price, 24, 'M')
-  }
-  if (priceStr.length > 21) {
-    return prettifyNumberWithUnit(price, 21, 'K')
-  }
-  return prettifyNumberWithUnit(price, 18, '')
-}
-
-function prettifyNumberWithUnit(number: bigint, decimals: number, unit: string): string | undefined {
-  const prettifyAmount = prettifyNumber(number, decimals, prettifyConfig)
-  if (prettifyAmount === undefined) return undefined
-  return prettifyAmount + unit
-}
 
 export default NFTCard;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alephium-nft",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev -p 3020",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,12 @@
 import Image from 'next/image';
 import images from '../assets';
 import { withTransition, CreatorCard } from '../components';
-import { prettifyAttoAlphAmount } from '@alephium/web3';
 import { addressToCreatorImage, shortenAddress } from '../utils/address';
 import { useState, useEffect, useRef, MutableRefObject } from 'react';
 import { useTheme } from 'next-themes';
 import axios from "axios"
 import { ListNFTListings } from '../components/NFTListing';
+import { formatAlphAmount } from '../utils';
 
 const Home = () => {
   const [hideButtons, setHideButtons] = useState(false);
@@ -63,6 +63,11 @@ const Home = () => {
     };
   });
 
+  const expandBigInt = (amount: string) => {
+    const expandedNumberStr = Number(amount).toLocaleString('fullwide', { useGrouping: false })
+    return BigInt(expandedNumberStr)
+  }
+
   return (
     <div className="flex justify-center p-12">
       <div className="w-full ml-32 mr-32 md:ml-20 md:mr-20 sm:ml-10 sm:mr-10">
@@ -80,7 +85,7 @@ const Home = () => {
                       rank={`${i + 1}`}
                       creatorImage={addressToCreatorImage(seller.address)}
                       creatorName={shortenAddress(seller.address)}
-                      creatorAlphs={prettifyAttoAlphAmount(seller.totalAmount) || ''}
+                      creatorAlphs={formatAlphAmount(expandBigInt(seller.totalAmount)) || ''}
                     />
                   ))}
                   {!hideButtons && (

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,6 +2,7 @@ import * as web3 from '@alephium/web3'
 import { addressFromContractId, binToHex, contractIdFromAddress, NodeProvider, node } from '@alephium/web3'
 import * as base58 from 'bs58'
 import { randomBytes } from 'crypto'
+import { ONE_ALPH, prettifyNumber, prettifyNumberConfig } from '@alephium/web3';
 
 export function checkHexString(value: any, expected: string) {
   expect(web3.hexToString(value)).toEqual(expected)
@@ -55,4 +56,34 @@ export async function contractExists(contractId: string, provider: NodeProvider)
       }
       throw e
     })
+}
+
+const prettifyConfig = {
+  ...prettifyNumberConfig['ALPH'],
+  maxDecimalPlaces: 2
+}
+
+export function formatAlphAmount(price: bigint): string | undefined {
+  const priceStr = price.toString()
+  if (priceStr.length > 30) {
+    const result = (Number(price) / Number(ONE_ALPH * 1000000000000n)).toExponential(2)
+    return result + 'T'
+  }
+
+  if (priceStr.length > 27) {
+    return prettifyNumberWithUnit(price, 27, 'B')
+  }
+  if (priceStr.length > 24) {
+    return prettifyNumberWithUnit(price, 24, 'M')
+  }
+  if (priceStr.length > 21) {
+    return prettifyNumberWithUnit(price, 21, 'K')
+  }
+  return prettifyNumberWithUnit(price, 18, '')
+}
+
+function prettifyNumberWithUnit(number: bigint, decimals: number, unit: string): string | undefined {
+  const prettifyAmount = prettifyNumber(number, decimals, prettifyConfig)
+  if (prettifyAmount === undefined) return undefined
+  return prettifyAmount + unit
 }


### PR DESCRIPTION
When a number is too big, Mongo is returning the number with scientific notation, such as `1.157920892373162e+75`. 

FE can not handle this number and stops loading. This PR fixes that.

We probably should limit the highest price an NFT should be, perhaps to total supply of ALPH.